### PR TITLE
fix constraints misspelling

### DIFF
--- a/agenda_backend/config/routes.rb
+++ b/agenda_backend/config/routes.rb
@@ -3,7 +3,7 @@ Rails.application.routes.draw do
     get 'agenda/all'
   end
 
-  namespace :api, contraints: { format: :json } do
+  namespace :api, constraints: { format: :json } do
     get 'people', to: 'agenda#all'
   end
 


### PR DESCRIPTION
I found this misspelling in your tutorial and config/routes.rb file. 
This resolves issue #1 .